### PR TITLE
feat: open squares around

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,7 +46,6 @@
 
 .col.opened {
   background-color: white;
-  pointer-events: none;
 }
 
 .col[data-count="1"] {

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,13 @@ import { useState } from "react";
 import classNames from "classnames";
 import Col from "./Col";
 import Controller from "./Controller";
-import { initBoard, placeMines, openCol, flagCol } from "./utils";
+import {
+  initBoard,
+  placeMines,
+  openCol,
+  flagCol,
+  openSquaresAround,
+} from "./utils";
 import { GameStatus } from "./constants";
 import "./App.css";
 
@@ -20,7 +26,6 @@ function App() {
     const { boardUpdated, mineBoomed } = openCol({ board, row, col });
 
     if (mineBoomed) {
-      console.log("game over", { row, col });
       setGameStatus(GameStatus.Failed);
     }
 
@@ -45,6 +50,11 @@ function App() {
     setBoard([...boardUpdated]);
   };
 
+  const onOpenSquareAround = ({ row, col }) => {
+    const boardUpdated = openSquaresAround({ board, row, col });
+    setBoard([...boardUpdated]);
+  };
+
   return (
     <div className="App">
       <div className={boardClass}>
@@ -58,6 +68,7 @@ function App() {
                 {...col}
                 onClick={onColClick}
                 onContextMenu={onColFlag}
+                onDoubleClick={onOpenSquareAround}
               />
             ))}
           </div>

--- a/src/Col/index.js
+++ b/src/Col/index.js
@@ -10,6 +10,7 @@ const Col = ({
   count,
   onClick,
   onContextMenu,
+  onDoubleClick,
 }) => {
   const display = useMemo(() => {
     if (isFlag) return "🚩";
@@ -20,19 +21,26 @@ const Col = ({
   }, [isOpen, isMine, isFlag, count]);
 
   const colClass = classNames("col", { opened: isOpen });
-  const clickHandler = (event) => {
+
+  const clickHandler = () => {
+    if (isOpen) return;
     if (isFlag) return;
     onClick({ row, col });
   };
+
   const contextMenuHandler = (event) => {
     event.preventDefault();
     onContextMenu({ row, col });
   };
+
+  const doubleClickHandler = () => onDoubleClick({ row, col });
+
   return (
     <div
       className={colClass}
       onClick={clickHandler}
       onContextMenu={contextMenuHandler}
+      onDoubleClick={doubleClickHandler}
       data-count={count}
     >
       {display}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -51,16 +51,20 @@ export const placeMines = ({ board, mines, entryCoordinate }) => {
 };
 
 const countMinesAround = ({ board, row, col }) => {
-  let count = 0;
-
-  if (board?.[row - 1]?.[col]?.isMine) count++;
-  if (board?.[row - 1]?.[col - 1]?.isMine) count++;
-  if (board?.[row - 1]?.[col + 1]?.isMine) count++;
-  if (board?.[row]?.[col - 1]?.isMine) count++;
-  if (board?.[row]?.[col + 1]?.isMine) count++;
-  if (board?.[row + 1]?.[col - 1]?.isMine) count++;
-  if (board?.[row + 1]?.[col]?.isMine) count++;
-  if (board?.[row + 1]?.[col + 1]?.isMine) count++;
+  const squaresAround = [
+    [row - 1, col],
+    [row - 1, col - 1],
+    [row - 1, col + 1],
+    [row, col - 1],
+    [row, col + 1],
+    [row + 1, col - 1],
+    [row + 1, col],
+    [row + 1, col + 1],
+  ];
+  const count = squaresAround.reduce((accumulator, [row, col]) => {
+    if (board?.[row]?.[col]?.isMine) accumulator++;
+    return accumulator;
+  }, 0);
 
   return count;
 };
@@ -117,5 +121,36 @@ export const openCol = ({ board, row, col }) => {
 export const flagCol = ({ board, row, col }) => {
   board[row][col].isFlag = !board[row][col].isFlag;
 
+  return board;
+};
+
+export const openSquaresAround = ({ board, row, col }) => {
+  const count = board[row][col].count;
+  const squaresAround = [
+    [row - 1, col],
+    [row - 1, col - 1],
+    [row - 1, col + 1],
+    [row, col - 1],
+    [row, col + 1],
+    [row + 1, col - 1],
+    [row + 1, col],
+    [row + 1, col + 1],
+  ];
+
+  const flags = squaresAround.reduce((accumulator, [row, col]) => {
+    if (board?.[row]?.[col]?.isFlag) accumulator++;
+    return accumulator;
+  }, 0);
+
+  if (count === flags) {
+    squaresAround.forEach(([row, col]) => {
+      const squareObj = board?.[row]?.[col];
+
+      if (!squareObj) return;
+      const count = countMinesAround({ board, row, col });
+      squareObj.isOpen = true;
+      squareObj.count = count;
+    }, 0);
+  }
   return board;
 };


### PR DESCRIPTION
# Description
If the number in a square is equal to the number of squares touching that square that are flagged, double clicking on the number opens up all remaining squares around the number. 